### PR TITLE
Update linuxbrew.plugin.zsh

### DIFF
--- a/linuxbrew.plugin.zsh
+++ b/linuxbrew.plugin.zsh
@@ -1,15 +1,15 @@
-#!/usr/bin/env zsh
+local BREW_PREFIX="$HOME/.linuxbrew"
 
-if [[ ! -d "$HOME/.linuxbrew" ]]; then
-  git clone https://github.com/Linuxbrew/brew ~/.linuxbrew </dev/null >/dev/null 2>/dev/null &!
+if [[ ! -d "$BREW_PREFIX" ]]; then
+  git clone https://github.com/Linuxbrew/brew "$BREW_PREFIX" </dev/null >/dev/null 2>/dev/null &!
 fi
 
-if [[ -d "$HOME/.linuxbrew" ]]; then
-  if [[ ":$PATH:" != *":${HOME}/.linuxbrew/bin:"* ]]; then
-    export PATH="$HOME/.linuxbrew/bin:$PATH"
-    export MANPATH="$HOME/.linuxbrew/share/man:$MANPATH"
-    export INFOPATH="$HOME/.linuxbrew/share/info:$INFOPATH"
+if [[ -d "$BREW_PREFIX" ]]; then
+  if [[ ":$PATH:" != *":$BREW_PREFIX/sbin:"* ]]; then
+    export PATH="$BREW_PREFIX/sbin:$BREW_PREFIX/bin:$PATH"
+    export MANPATH="$BREW_PREFIX/share/man:$MANPATH"
+    export INFOPATH="$BREW_PREFIX/share/info:$INFOPATH"
+    export XDG_DATA_DIRS="$BREW_PREFIX/share:$XDG_DATA_DIRS"
   fi
-    fpath=( "$HOME/.linuxbrew/completions/zsh" $fpath )
+    fpath=( "$BREW_PREFIX/completions/zsh" $fpath )
 fi
-


### PR DESCRIPTION
- remove #! line since this would already be being executed from zsh if it's a plugin, right? (also /usr/bin/env isn't always there e.g. termux)
- add sbin to the path (e.g. privoxy formula installs there)
- add XDG_DATA_DIRS recommended in the linuxbrew-wrapper post install message